### PR TITLE
feat: release v0.1.1

### DIFF
--- a/releases/latest/component.css
+++ b/releases/latest/component.css
@@ -1,0 +1,3 @@
+.machine-driver.%%DRIVERNAME%% {
+  background-image: url('LOGO_IONOS_Blue_RGB.svg');
+}

--- a/releases/latest/component.js
+++ b/releases/latest/component.js
@@ -1,0 +1,171 @@
+/*!!!!!!!!!!!Do not change anything between here (the DRIVERNAME placeholder will be automatically replaced at buildtime)!!!!!!!!!!!*/
+import NodeDriver from 'shared/mixins/node-driver';
+
+// do not remove LAYOUT, it is replaced at build time with a base64 representation of the template of the hbs template
+// we do this to avoid converting template to a js file that returns a string and the cors issues that would come along with that
+const LAYOUT;
+/*!!!!!!!!!!!DO NOT CHANGE END!!!!!!!!!!!*/
+
+
+/*!!!!!!!!!!!GLOBAL CONST START!!!!!!!!!!!*/
+// EMBER API Access - if you need access to any of the Ember API's add them here in the same manner rather then import them via modules, since the dependencies exist in rancher we dont want to expor the modules in the amd def
+const computed     = Ember.computed;
+const get          = Ember.get;
+const set          = Ember.set;
+const alias        = Ember.computed.alias;
+const service      = Ember.inject.service;
+
+const defaultRadix = 10;
+const defaultBase  = 1024;
+/*!!!!!!!!!!!GLOBAL CONST END!!!!!!!!!!!*/
+
+
+
+/*!!!!!!!!!!!DO NOT CHANGE START!!!!!!!!!!!*/
+export default Ember.Component.extend(NodeDriver, {
+  driverName: '%%DRIVERNAME%%',
+  config:     alias('model.%%DRIVERNAME%%Config'),
+  app:        service(),
+
+  init() {
+    // This does on the fly template compiling, if you mess with this :cry:
+    const decodedLayout = window.atob(LAYOUT);
+    const template      = Ember.HTMLBars.compile(decodedLayout, {
+      moduleName: 'nodes/components/driver-%%DRIVERNAME%%/template'
+    });
+    set(this,'layout', template);
+
+    this._super(...arguments);
+
+  },
+  /*!!!!!!!!!!!DO NOT CHANGE END!!!!!!!!!!!*/
+
+  // Write your component here, starting with setting 'model' to a machine with your config populated
+  bootstrap: function() {
+    // bootstrap is called by rancher ui on 'init', you're better off doing your setup here rather then the init function to ensure everything is setup correctly
+    let config = get(this, 'globalStore').createRecord({
+      type: '%%DRIVERNAME%%Config',
+      cores: 2,
+      ram: 2048,
+      userData: '',
+      token: '',
+      username: '',
+      password: '',
+      endpoint: 'https://api.ionos.com/cloudapi/v6',
+
+    });
+
+    set(this, 'model.%%DRIVERNAME%%Config', config);
+  },
+
+  // Add custom validation beyond what can be done from the config API schema
+  validate() {
+    // Get generic API validation errors
+    this._super();
+    var errors = get(this, 'errors')||[];
+    if ( !get(this, 'model.name') ) {
+      errors.push('Name is required');
+    }
+
+    // Add more specific errors
+
+    // Check something and add an error entry if it fails:
+    if ( parseInt(get(this, 'config.memorySize'), defaultRadix) < defaultBase ) {
+      errors.push('Memory Size must be at least 1024 MB');
+    }
+
+    // Set the array of errors for display,
+    // and return true if saving should continue.
+    if ( get(errors, 'length') ) {
+      set(this, 'errors', errors);
+      return false;
+    } else {
+      set(this, 'errors', null);
+      return true;
+    }
+  },
+
+  // Any computed properties or custom logic can go here
+  // duplicated dict k/v pairs in favor of cleaner hbs template - be my guest if you want to change this
+  zoneOptions: [
+    {
+      name: 'AUTO',
+      value: 'AUTO',
+    },
+    {
+      name: 'ZONE_1',
+      value: 'ZONE_1',
+    },
+    {
+      name: 'ZONE_2',
+      value: 'ZONE_2',
+    },
+    {
+      name: 'ZONE_3',
+      value: 'ZONE_3',
+    },
+  ],
+
+  // TODO: Should restrict CPU locations based on the location chosen
+  // TODO: Should be restricted by DatacenterID to the Datacenter's location, if set
+  locationOptions: [
+    {
+      name: 'Las Vegas, USA',
+      value: 'us/las',
+    },
+    {
+      name: 'Newark, USA',
+      value: 'us/ewr',
+    },
+    {
+      name: 'Frankfurt, Germany',
+      value: 'de/fra',
+    },
+    {
+      name: 'Berlin, Germany',
+      value: 'de/txl',
+    },
+    {
+      name: 'London, UK',
+      value: 'gb/lhr',
+    },
+    {
+      name: 'Logroño, Spain',
+      value: 'es/vit',
+    },
+    {
+      name: 'Paris, France',
+      value: 'fr/par',
+    },
+  ],
+
+  // Do you have a better option? Open a PR or an issue!
+  // TODO: Should be restricted by LocationOptions.
+  cpuOptions: [
+    {
+      name: 'Intel SKYLAKE (Europe)',
+      value: 'INTEL_SKYLAKE',
+    },
+    {
+      name: 'AMD OPTERON (USA)',
+      value: 'AMD_OPTERON',
+    },
+    {
+      name: 'Intel XEON (USA)',
+      value: 'INTEL_XEON',
+    },
+  ],
+
+  // Do you have a better option? Open a PR or an issue!
+  storageTypeOptions: [
+    {
+      name: 'HDD',
+      value: 'HDD',
+    },
+    {
+      name: 'SSD',
+      value: 'SSD'
+    },
+  ]
+});
+

--- a/releases/latest/rexport.js
+++ b/releases/latest/rexport.js
@@ -1,0 +1,1 @@
+export { default } from 'nodes/components/driver-%%DRIVERNAME%%/component';

--- a/releases/latest/template.hbs
+++ b/releases/latest/template.hbs
@@ -1,0 +1,251 @@
+<section class="horizontal-form">
+  {{#accordion-list showExpandAll=false as | al expandFn |}}
+    {{!-- This line shows the driver title which you don't have to change it --}}
+    <div class="over-hr mb-20"><span>{{driverOptionsTitle}}</span></div>
+
+    {{#accordion-list-item title="Account Access"
+                           detail="API endpoint and credentials."
+                           expandAll=expandAll
+                           expand=(action expandFn)
+                           expandOnInit=true
+    }}
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">Username. Fallback to Token if not set.</label>
+          {{input type="text"
+                  class="form-control"
+                  value=config.username
+                  placeholder="Your IONOS username"
+          }}
+        </div>
+        <div class="col span-6">
+          <label class="acc-label">Password. Fallback to Token if not set.</label>
+          {{input type="password"
+                  class="form-control"
+                  value=config.password
+                  placeholder="Your IONOS password"
+          }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-12">
+          <label class="acc-label">API Token (Overrides Username & Password)</label>
+          {{input type="password"
+              class="form-control"
+              value=config.token
+              placeholder="Your IONOS token"
+          }}
+          <p class="help-block">You can use <a href="https://docs.ionos.com/cli-ionosctl/subcommands/authentication/token-generate" target="_blank" rel="noopener noreferrer">ionosctl</a> to generate an API token.</p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-12">
+          <label class="acc-label">API Endpoint</label>
+          {{input type="text"
+              class="form-control"
+              value=config.endpoint
+              placeholder="https://api.ionos.com/cloudapi/v6"
+          }}
+          <p class="help-block">Optional</p>
+        </div>
+      </div>
+    {{/accordion-list-item}}
+
+    {{#accordion-list-item title="Instance Options"
+                           detail="VM settings. Set up your core count & ram."
+                           expandAll=expandAll
+                           expand=(action expandFn)
+                           expandOnInit=false
+    }}
+      <div class="row">
+        <div class="col span-3">
+          <label class="acc-label">Location</label>
+            {{new-select class="form-control"
+                         content=locationOptions
+                         optionLabelPath='name'
+                         optionValuePath='value'
+                         value=config.location
+            }}
+        </div>
+        <div class="col span-3">
+          <label class="acc-label">CPU Family</label>
+            {{new-select class="form-control"
+                         content=cpuOptions
+                         optionLabelPath='name'
+                         optionValuePath='value'
+                         value=config.cpuFamily
+            }}
+        </div>
+        <div class="col span-3">
+          <label class="acc-label">Server Zone</label>
+          {{new-select class="form-control"
+                       content=zoneOptions
+                       optionLabelPath='name'
+                       optionValuePath='value'
+                       value=config.serverZone
+          }}
+        </div>
+        <div class="col span-3">
+          <label class="acc-label">Volume Zone</label>
+          {{new-select class="form-control"
+                       content=zoneOptions
+                       optionLabelPath='name'
+                       optionValuePath='value'
+                       value=config.volumeZone
+          }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">CPU core count</label>
+          {{input-integer
+            value=config.cores
+            placeholder=4
+            classNames="form-control"
+          }}
+        </div>
+        <div class="col span-6">
+          <label class="acc-label">RAM</label>
+          <div class="input-group">
+            {{input-integer min=256
+                            value=config.ram
+                            classNames="form-control"
+            }}
+            <div class="input-group-addon bg-default">MiB</div>
+          </div>
+          <p class="help-block">Must be a multiple of 256</p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">Storage Size</label>
+          <div class="input-group">
+            {{input-integer value=config.diskSize
+                            classNames="form-control"
+            }}
+            <div class="input-group-addon bg-default">GB</div>
+          </div>
+        </div>
+        <div class="col span-6">
+          <label class="acc-label">Storage Type</label>
+          {{new-select class="form-control"
+                       content=storageTypeOptions
+                       optionLabelPath='name'
+                       optionValuePath='value'
+                       value=config.diskType
+          }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">Image Alias or ID</label>
+          {{input type="text"
+                  value=config.image
+                  placeholder="ubuntu:18.04"
+                  classNames="form-control"
+          }}
+          <p class="help-block">You can use <a href="https://docs.ionos.com/cli-ionosctl" target="_blank" rel="noopener noreferrer">ionosctl image list [-F name=operatingSystem]</a></p>
+        </div>
+        <div class="col span-6">
+          <label class="acc-label">Image Password</label>
+          {{input type="password"
+                  value=config.imagePassword
+                  placeholder="abcde12345"
+                  classNames="form-control"
+          }}
+          <p class="help-block">Can be used to connect to the VM</p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-12">
+          <label class="acc-label">Cloud init configuration.</label>
+          <textarea id="editor" value={{config.userData}} onchange={{action (mut config.userData) value="target.value" }} rows="3" style="width: 100%; resize: vertical"></textarea>
+          <p class="help-block">Optional. <a href="https://cloudinit.readthedocs.io/en/latest/topics/examples.html" target="_blank" rel="noopener noreferrer">Cloud-init Documentation</a>.</p>
+        </div>
+      </div>
+    {{/accordion-list-item}}
+
+    {{#accordion-list-item title="Network Options"
+                           detail="Set up your target Datacenter, LAN, and other network settings here."
+                           expandAll=expandAll
+                           expand=(action expandFn)
+                           expandOnInit=false
+    }}
+      <div class="row">
+        <div class="col span-12">
+          <label class="acc-label">SSH User</label>
+          {{input type="text"
+                  value=config.sshUser
+                  classNames="form-control"
+          }}
+          <p class="help-block">Optional. User to connect to via SSH.</p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-9">
+          <label class="acc-label">IONOS Datacenter ID</label>
+          {{input type="text"
+                  value=config.datacenterId
+                  classNames="form-control"
+          }}
+          <p class="help-block">Optional, UUID-4 format. If you want to use an existing IONOS Datacenter to host this VM, you can provide its ID here.</p>
+        </div>
+        <div class="col span-3">
+          <label class="acc-label">IONOS Lan ID</label>
+          {{input-integer
+            value=config.lanId
+            classNames="form-control"
+          }}
+          <p class="help-block">Optional, integer. You can provide one of the LANs on the given Datacenter.</p>
+        </div>
+      </div>
+
+    {{/accordion-list-item}}
+
+      <!--    Uncomment lines here to add ACE editor for CloudINIT. TODO-->
+<!--      <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.13.1/ace.js" integrity="sha512-IQmiIneKUJhTJElpHOlsrb3jpF7r54AzhCTi7BTDLiBVg0f7mrEqWVCmOeoqKv5hDdyf3rbbxBUgYf4u3O/QcQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>-->
+<!--      <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.13.1/ext-language_tools.min.js" integrity="sha512-yszTJ9Ko+JGmUNZYpHStWpMg2rSXrh2WjSSZGydzpHY+qOS/3nSgA+hBHUK3RvLhfjycKL8XWEmfUCZod/mEqA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>-->
+<!--      <script>-->
+<!--        // ace.require("ace/ext/language_tools");-->
+<!--        const editor = ace.edit("editor");-->
+<!--        editor.setTheme("ace/theme/twilight");-->
+<!--        editor.session.setMode("ace/mode/c_cpp");-->
+<!--        editor.setOptions({-->
+<!--          enableBasicAutocompletion: true,-->
+<!--          enableSnippets: true,-->
+<!--          enableLiveAutocompletion: true-->
+<!--        });-->
+<!--        editor.resize();-->
+<!--      </script>-->
+
+    {{!-- This following contains the Name, Labels and Engine Options fields --}}
+    <div class="over-hr"><span>{{templateOptionsTitle}}</span></div>
+
+    {{form-name-description
+      model=model
+      nameRequired=true
+    }}
+
+    {{form-user-labels
+      initialLabels=labelResource.labels
+      setLabels=(action 'setLabels')
+      expandAll=expandAll
+      expand=(action expandFn)
+    }}
+
+    {{form-engine-opts
+      machine=model
+      showEngineUrl=showEngineUrl
+    }}
+  {{/accordion-list}}
+
+  {{!-- This component shows errors produced by validate() in the component --}}
+  {{top-errors errors=errors}}
+
+  {{!-- This component shows the Create and Cancel buttons --}}
+  {{save-cancel
+    save=(action "save")
+    cancel=(action "cancel")
+    editing=editing
+  }}
+</section>

--- a/releases/v0.1.1/component.css
+++ b/releases/v0.1.1/component.css
@@ -1,0 +1,3 @@
+.machine-driver.%%DRIVERNAME%% {
+  background-image: url('LOGO_IONOS_Blue_RGB.svg');
+}

--- a/releases/v0.1.1/component.js
+++ b/releases/v0.1.1/component.js
@@ -1,0 +1,171 @@
+/*!!!!!!!!!!!Do not change anything between here (the DRIVERNAME placeholder will be automatically replaced at buildtime)!!!!!!!!!!!*/
+import NodeDriver from 'shared/mixins/node-driver';
+
+// do not remove LAYOUT, it is replaced at build time with a base64 representation of the template of the hbs template
+// we do this to avoid converting template to a js file that returns a string and the cors issues that would come along with that
+const LAYOUT;
+/*!!!!!!!!!!!DO NOT CHANGE END!!!!!!!!!!!*/
+
+
+/*!!!!!!!!!!!GLOBAL CONST START!!!!!!!!!!!*/
+// EMBER API Access - if you need access to any of the Ember API's add them here in the same manner rather then import them via modules, since the dependencies exist in rancher we dont want to expor the modules in the amd def
+const computed     = Ember.computed;
+const get          = Ember.get;
+const set          = Ember.set;
+const alias        = Ember.computed.alias;
+const service      = Ember.inject.service;
+
+const defaultRadix = 10;
+const defaultBase  = 1024;
+/*!!!!!!!!!!!GLOBAL CONST END!!!!!!!!!!!*/
+
+
+
+/*!!!!!!!!!!!DO NOT CHANGE START!!!!!!!!!!!*/
+export default Ember.Component.extend(NodeDriver, {
+  driverName: '%%DRIVERNAME%%',
+  config:     alias('model.%%DRIVERNAME%%Config'),
+  app:        service(),
+
+  init() {
+    // This does on the fly template compiling, if you mess with this :cry:
+    const decodedLayout = window.atob(LAYOUT);
+    const template      = Ember.HTMLBars.compile(decodedLayout, {
+      moduleName: 'nodes/components/driver-%%DRIVERNAME%%/template'
+    });
+    set(this,'layout', template);
+
+    this._super(...arguments);
+
+  },
+  /*!!!!!!!!!!!DO NOT CHANGE END!!!!!!!!!!!*/
+
+  // Write your component here, starting with setting 'model' to a machine with your config populated
+  bootstrap: function() {
+    // bootstrap is called by rancher ui on 'init', you're better off doing your setup here rather then the init function to ensure everything is setup correctly
+    let config = get(this, 'globalStore').createRecord({
+      type: '%%DRIVERNAME%%Config',
+      cores: 2,
+      ram: 2048,
+      userData: '',
+      token: '',
+      username: '',
+      password: '',
+      endpoint: 'https://api.ionos.com/cloudapi/v6',
+
+    });
+
+    set(this, 'model.%%DRIVERNAME%%Config', config);
+  },
+
+  // Add custom validation beyond what can be done from the config API schema
+  validate() {
+    // Get generic API validation errors
+    this._super();
+    var errors = get(this, 'errors')||[];
+    if ( !get(this, 'model.name') ) {
+      errors.push('Name is required');
+    }
+
+    // Add more specific errors
+
+    // Check something and add an error entry if it fails:
+    if ( parseInt(get(this, 'config.memorySize'), defaultRadix) < defaultBase ) {
+      errors.push('Memory Size must be at least 1024 MB');
+    }
+
+    // Set the array of errors for display,
+    // and return true if saving should continue.
+    if ( get(errors, 'length') ) {
+      set(this, 'errors', errors);
+      return false;
+    } else {
+      set(this, 'errors', null);
+      return true;
+    }
+  },
+
+  // Any computed properties or custom logic can go here
+  // duplicated dict k/v pairs in favor of cleaner hbs template - be my guest if you want to change this
+  zoneOptions: [
+    {
+      name: 'AUTO',
+      value: 'AUTO',
+    },
+    {
+      name: 'ZONE_1',
+      value: 'ZONE_1',
+    },
+    {
+      name: 'ZONE_2',
+      value: 'ZONE_2',
+    },
+    {
+      name: 'ZONE_3',
+      value: 'ZONE_3',
+    },
+  ],
+
+  // TODO: Should restrict CPU locations based on the location chosen
+  // TODO: Should be restricted by DatacenterID to the Datacenter's location, if set
+  locationOptions: [
+    {
+      name: 'Las Vegas, USA',
+      value: 'us/las',
+    },
+    {
+      name: 'Newark, USA',
+      value: 'us/ewr',
+    },
+    {
+      name: 'Frankfurt, Germany',
+      value: 'de/fra',
+    },
+    {
+      name: 'Berlin, Germany',
+      value: 'de/txl',
+    },
+    {
+      name: 'London, UK',
+      value: 'gb/lhr',
+    },
+    {
+      name: 'Logroño, Spain',
+      value: 'es/vit',
+    },
+    {
+      name: 'Paris, France',
+      value: 'fr/par',
+    },
+  ],
+
+  // Do you have a better option? Open a PR or an issue!
+  // TODO: Should be restricted by LocationOptions.
+  cpuOptions: [
+    {
+      name: 'Intel SKYLAKE (Europe)',
+      value: 'INTEL_SKYLAKE',
+    },
+    {
+      name: 'AMD OPTERON (USA)',
+      value: 'AMD_OPTERON',
+    },
+    {
+      name: 'Intel XEON (USA)',
+      value: 'INTEL_XEON',
+    },
+  ],
+
+  // Do you have a better option? Open a PR or an issue!
+  storageTypeOptions: [
+    {
+      name: 'HDD',
+      value: 'HDD',
+    },
+    {
+      name: 'SSD',
+      value: 'SSD'
+    },
+  ]
+});
+

--- a/releases/v0.1.1/rexport.js
+++ b/releases/v0.1.1/rexport.js
@@ -1,0 +1,1 @@
+export { default } from 'nodes/components/driver-%%DRIVERNAME%%/component';

--- a/releases/v0.1.1/template.hbs
+++ b/releases/v0.1.1/template.hbs
@@ -1,0 +1,251 @@
+<section class="horizontal-form">
+  {{#accordion-list showExpandAll=false as | al expandFn |}}
+    {{!-- This line shows the driver title which you don't have to change it --}}
+    <div class="over-hr mb-20"><span>{{driverOptionsTitle}}</span></div>
+
+    {{#accordion-list-item title="Account Access"
+                           detail="API endpoint and credentials."
+                           expandAll=expandAll
+                           expand=(action expandFn)
+                           expandOnInit=true
+    }}
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">Username. Fallback to Token if not set.</label>
+          {{input type="text"
+                  class="form-control"
+                  value=config.username
+                  placeholder="Your IONOS username"
+          }}
+        </div>
+        <div class="col span-6">
+          <label class="acc-label">Password. Fallback to Token if not set.</label>
+          {{input type="password"
+                  class="form-control"
+                  value=config.password
+                  placeholder="Your IONOS password"
+          }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-12">
+          <label class="acc-label">API Token (Overrides Username & Password)</label>
+          {{input type="password"
+              class="form-control"
+              value=config.token
+              placeholder="Your IONOS token"
+          }}
+          <p class="help-block">You can use <a href="https://docs.ionos.com/cli-ionosctl/subcommands/authentication/token-generate" target="_blank" rel="noopener noreferrer">ionosctl</a> to generate an API token.</p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-12">
+          <label class="acc-label">API Endpoint</label>
+          {{input type="text"
+              class="form-control"
+              value=config.endpoint
+              placeholder="https://api.ionos.com/cloudapi/v6"
+          }}
+          <p class="help-block">Optional</p>
+        </div>
+      </div>
+    {{/accordion-list-item}}
+
+    {{#accordion-list-item title="Instance Options"
+                           detail="VM settings. Set up your core count & ram."
+                           expandAll=expandAll
+                           expand=(action expandFn)
+                           expandOnInit=false
+    }}
+      <div class="row">
+        <div class="col span-3">
+          <label class="acc-label">Location</label>
+            {{new-select class="form-control"
+                         content=locationOptions
+                         optionLabelPath='name'
+                         optionValuePath='value'
+                         value=config.location
+            }}
+        </div>
+        <div class="col span-3">
+          <label class="acc-label">CPU Family</label>
+            {{new-select class="form-control"
+                         content=cpuOptions
+                         optionLabelPath='name'
+                         optionValuePath='value'
+                         value=config.cpuFamily
+            }}
+        </div>
+        <div class="col span-3">
+          <label class="acc-label">Server Zone</label>
+          {{new-select class="form-control"
+                       content=zoneOptions
+                       optionLabelPath='name'
+                       optionValuePath='value'
+                       value=config.serverZone
+          }}
+        </div>
+        <div class="col span-3">
+          <label class="acc-label">Volume Zone</label>
+          {{new-select class="form-control"
+                       content=zoneOptions
+                       optionLabelPath='name'
+                       optionValuePath='value'
+                       value=config.volumeZone
+          }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">CPU core count</label>
+          {{input-integer
+            value=config.cores
+            placeholder=4
+            classNames="form-control"
+          }}
+        </div>
+        <div class="col span-6">
+          <label class="acc-label">RAM</label>
+          <div class="input-group">
+            {{input-integer min=256
+                            value=config.ram
+                            classNames="form-control"
+            }}
+            <div class="input-group-addon bg-default">MiB</div>
+          </div>
+          <p class="help-block">Must be a multiple of 256</p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">Storage Size</label>
+          <div class="input-group">
+            {{input-integer value=config.diskSize
+                            classNames="form-control"
+            }}
+            <div class="input-group-addon bg-default">GB</div>
+          </div>
+        </div>
+        <div class="col span-6">
+          <label class="acc-label">Storage Type</label>
+          {{new-select class="form-control"
+                       content=storageTypeOptions
+                       optionLabelPath='name'
+                       optionValuePath='value'
+                       value=config.diskType
+          }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">Image Alias or ID</label>
+          {{input type="text"
+                  value=config.image
+                  placeholder="ubuntu:18.04"
+                  classNames="form-control"
+          }}
+          <p class="help-block">You can use <a href="https://docs.ionos.com/cli-ionosctl" target="_blank" rel="noopener noreferrer">ionosctl image list [-F name=operatingSystem]</a></p>
+        </div>
+        <div class="col span-6">
+          <label class="acc-label">Image Password</label>
+          {{input type="password"
+                  value=config.imagePassword
+                  placeholder="abcde12345"
+                  classNames="form-control"
+          }}
+          <p class="help-block">Can be used to connect to the VM</p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-12">
+          <label class="acc-label">Cloud init configuration.</label>
+          <textarea id="editor" value={{config.userData}} onchange={{action (mut config.userData) value="target.value" }} rows="3" style="width: 100%; resize: vertical"></textarea>
+          <p class="help-block">Optional. <a href="https://cloudinit.readthedocs.io/en/latest/topics/examples.html" target="_blank" rel="noopener noreferrer">Cloud-init Documentation</a>.</p>
+        </div>
+      </div>
+    {{/accordion-list-item}}
+
+    {{#accordion-list-item title="Network Options"
+                           detail="Set up your target Datacenter, LAN, and other network settings here."
+                           expandAll=expandAll
+                           expand=(action expandFn)
+                           expandOnInit=false
+    }}
+      <div class="row">
+        <div class="col span-12">
+          <label class="acc-label">SSH User</label>
+          {{input type="text"
+                  value=config.sshUser
+                  classNames="form-control"
+          }}
+          <p class="help-block">Optional. User to connect to via SSH.</p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-9">
+          <label class="acc-label">IONOS Datacenter ID</label>
+          {{input type="text"
+                  value=config.datacenterId
+                  classNames="form-control"
+          }}
+          <p class="help-block">Optional, UUID-4 format. If you want to use an existing IONOS Datacenter to host this VM, you can provide its ID here.</p>
+        </div>
+        <div class="col span-3">
+          <label class="acc-label">IONOS Lan ID</label>
+          {{input-integer
+            value=config.lanId
+            classNames="form-control"
+          }}
+          <p class="help-block">Optional, integer. You can provide one of the LANs on the given Datacenter.</p>
+        </div>
+      </div>
+
+    {{/accordion-list-item}}
+
+      <!--    Uncomment lines here to add ACE editor for CloudINIT. TODO-->
+<!--      <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.13.1/ace.js" integrity="sha512-IQmiIneKUJhTJElpHOlsrb3jpF7r54AzhCTi7BTDLiBVg0f7mrEqWVCmOeoqKv5hDdyf3rbbxBUgYf4u3O/QcQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>-->
+<!--      <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.13.1/ext-language_tools.min.js" integrity="sha512-yszTJ9Ko+JGmUNZYpHStWpMg2rSXrh2WjSSZGydzpHY+qOS/3nSgA+hBHUK3RvLhfjycKL8XWEmfUCZod/mEqA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>-->
+<!--      <script>-->
+<!--        // ace.require("ace/ext/language_tools");-->
+<!--        const editor = ace.edit("editor");-->
+<!--        editor.setTheme("ace/theme/twilight");-->
+<!--        editor.session.setMode("ace/mode/c_cpp");-->
+<!--        editor.setOptions({-->
+<!--          enableBasicAutocompletion: true,-->
+<!--          enableSnippets: true,-->
+<!--          enableLiveAutocompletion: true-->
+<!--        });-->
+<!--        editor.resize();-->
+<!--      </script>-->
+
+    {{!-- This following contains the Name, Labels and Engine Options fields --}}
+    <div class="over-hr"><span>{{templateOptionsTitle}}</span></div>
+
+    {{form-name-description
+      model=model
+      nameRequired=true
+    }}
+
+    {{form-user-labels
+      initialLabels=labelResource.labels
+      setLabels=(action 'setLabels')
+      expandAll=expandAll
+      expand=(action expandFn)
+    }}
+
+    {{form-engine-opts
+      machine=model
+      showEngineUrl=showEngineUrl
+    }}
+  {{/accordion-list}}
+
+  {{!-- This component shows errors produced by validate() in the component --}}
+  {{top-errors errors=errors}}
+
+  {{!-- This component shows the Create and Cancel buttons --}}
+  {{save-cancel
+    save=(action "save")
+    cancel=(action "cancel")
+    editing=editing
+  }}
+</section>


### PR DESCRIPTION
Added compiled files for release v0.1.1

Added option for users to always use the most up to date compiled js, regardless of what the current version is. As a developer, this implies creating a folder for your desired release version (i.e. v2.5.1), and copying the files from `dist` after `npm run build` to both this release version folder, and also overwriting all the files in the `latest` folder.

After merge, the `latest` version will be accessible at `https://cdn.jsdelivr.net/gh/ionos-cloud/ui-driver-ionoscloud@main/releases/latest/component.js`

If you want to test this release, you can use this link:   `https://cdn.jsdelivr.net/gh/ionos-cloud/ui-driver-ionoscloud@release/v0.1.1/releases/latest/component.js`